### PR TITLE
Move gulp* into develop dependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "main": "dist/emitter.js",
   "license": "MIT",
-  "dependencies": {
+  "devDependencies": {
     "gulp": "^3.9.0",
     "gulp-babel": "^5.3.0",
     "gulp-sourcemaps": "^1.6.0"


### PR DESCRIPTION
No need to install gulp when use as library.
